### PR TITLE
Added backend apis for Windows Filesystem-compatible apis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /backend/VsRemote.Sample/obj
 /backend/VsRemote/bin
 /backend/VsRemote.Sample/bin/Debug/net6.0
+/backend/VsRemote.Sample/bin/Debug/net8.0

--- a/backend/VsRemote.Sample/InMemoryIndexedDictionaryFilesystem.cs
+++ b/backend/VsRemote.Sample/InMemoryIndexedDictionaryFilesystem.cs
@@ -38,13 +38,14 @@ public class InMemoryIndexedDictionaryFilesystem : VsRemoteFileSystem<long>
             Name: directoryName,
             FileType: VsRemoteFileType.Directory,
             CTime: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
-            MTime: DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+            MTime: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ATime: DateTimeOffset.UtcNow.ToUnixTimeSeconds()
         );
         fs.AddOrUpdate(newDir.Key, newDir, (k, f) => throw new FileExists());
         return Task.CompletedTask;
     }
 
-    public override Task<long> CreateFile(string file2write, IVsRemoteINode<long> parentDir, ReadOnlyMemory<byte> content)
+    public override Task<int> CreateFile(string file2write, IVsRemoteINode<long> parentDir, ReadOnlyMemory<byte> content)
     {
         IVsRemoteINode<long> newFile = new VsRemoteINode<long>(
             Key: nextId,
@@ -53,11 +54,12 @@ public class InMemoryIndexedDictionaryFilesystem : VsRemoteFileSystem<long>
             FileType: VsRemoteFileType.File,
             CTime: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
             MTime: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ATime: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
             Size: content.Length
         );
         fs.AddOrUpdate(newFile.Key, newFile, (k, f) => throw new FileExists());
         contents.Add(newFile.Key, content);
-        return Task.FromResult((long)content.Length);
+        return Task.FromResult(content.Length);
     }
 
     public override Task DeleteFile(IVsRemoteINode<long> fileToDelete)
@@ -134,10 +136,10 @@ public class InMemoryIndexedDictionaryFilesystem : VsRemoteFileSystem<long>
         return Task.CompletedTask;
     }
 
-    public override Task<long> RewriteFile(IVsRemoteINode<long> file2rewrite, ReadOnlyMemory<byte> content)
+    public override Task<int> RewriteFile(IVsRemoteINode<long> file2rewrite, ReadOnlyMemory<byte> content)
     {
         contents[file2rewrite.Key] = content;
-        return Task.FromResult((long)content.Length);
+        return Task.FromResult(content.Length);
     }
 
 

--- a/backend/VsRemote.Sample/InMemoryIndexedDictionaryFilesystem.cs
+++ b/backend/VsRemote.Sample/InMemoryIndexedDictionaryFilesystem.cs
@@ -39,7 +39,8 @@ public class InMemoryIndexedDictionaryFilesystem : VsRemoteFileSystem<long>
             FileType: VsRemoteFileType.Directory,
             CTime: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
             MTime: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
-            ATime: DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+            ATime: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            Readonly: false
         );
         fs.AddOrUpdate(newDir.Key, newDir, (k, f) => throw new FileExists());
         return Task.CompletedTask;
@@ -55,6 +56,7 @@ public class InMemoryIndexedDictionaryFilesystem : VsRemoteFileSystem<long>
             CTime: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
             MTime: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
             ATime: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            Readonly: false,
             Size: content.Length
         );
         fs.AddOrUpdate(newFile.Key, newFile, (k, f) => throw new FileExists());

--- a/backend/VsRemote.Sample/LocalFolderFilesystem.cs
+++ b/backend/VsRemote.Sample/LocalFolderFilesystem.cs
@@ -72,10 +72,11 @@ public class LocalFolderFilesystem : VsRemoteFileSystem
                 new VsRemoteINode(
                     Path.GetFileName(path),
                     Directory.Exists(path) ? VsRemoteFileType.Directory : VsRemoteFileType.File,
-                    Readonly: (File.GetAttributes(path) | FileAttributes.ReadOnly) != 0,
+                    Readonly: (File.GetAttributes(path) & FileAttributes.ReadOnly) != 0,
                     ((DateTimeOffset)File.GetCreationTimeUtc(path)).ToUnixTimeSeconds(),
                     ((DateTimeOffset)File.GetLastWriteTimeUtc(path)).ToUnixTimeSeconds(),
-                    ((DateTimeOffset)File.GetLastAccessTimeUtc(path)).ToUnixTimeSeconds()
+                    ((DateTimeOffset)File.GetLastAccessTimeUtc(path)).ToUnixTimeSeconds(),
+                    Size: File.Exists(path) ? new System.IO.FileInfo(path).Length : 0
             ));
         }
         else
@@ -122,7 +123,7 @@ public class LocalFolderFilesystem : VsRemoteFileSystem
 
     public override Task RemoveDirectory(IVsRemoteINode dir, string[] path, bool recursive)
     {
-        return LocalRemoveDirectory(LocalPath(VsPath.Join(path, dir.Name)), recursive);
+        return LocalRemoveDirectory(LocalPath(VsPath.Join(path)), recursive);
     }
 
     public override Task RenameFile(IVsRemoteINode fromFile, string[] fromPath, string toName, string[] toPath)

--- a/backend/VsRemote.Sample/LocalFolderFilesystem.cs
+++ b/backend/VsRemote.Sample/LocalFolderFilesystem.cs
@@ -73,7 +73,8 @@ public class LocalFolderFilesystem : VsRemoteFileSystem
                     Path.GetFileName(path),
                     Directory.Exists(path) ? VsRemoteFileType.Directory : VsRemoteFileType.File,
                     ((DateTimeOffset)File.GetCreationTimeUtc(path)).ToUnixTimeSeconds(),
-                    ((DateTimeOffset)File.GetLastWriteTime(path)).ToUnixTimeSeconds()
+                    ((DateTimeOffset)File.GetLastWriteTimeUtc(path)).ToUnixTimeSeconds(),
+                    ((DateTimeOffset)File.GetLastAccessTimeUtc(path)).ToUnixTimeSeconds()
             ));
         }
         else
@@ -82,7 +83,7 @@ public class LocalFolderFilesystem : VsRemoteFileSystem
         }
     }
 
-    private async Task<long> LocalWriteFile(string path, ReadOnlyMemory<byte> content)
+    private async Task<int> LocalWriteFile(string path, ReadOnlyMemory<byte> content)
     {
         var stream = File.OpenWrite(path);
         stream.Seek(0, SeekOrigin.Begin);
@@ -136,7 +137,7 @@ public class LocalFolderFilesystem : VsRemoteFileSystem
         return LocalStat(LocalPath(VsPath.Join(path)));
     }
 
-    public override Task<long> WriteFile(string file2write, IVsRemoteINode parentDir, string[] parentPath, ReadOnlyMemory<byte> content)
+    public override Task<int> WriteFile(string file2write, IVsRemoteINode parentDir, string[] parentPath, ReadOnlyMemory<byte> content)
     {
         return LocalWriteFile(LocalPath(VsPath.Join(parentPath, file2write)), content);
     }

--- a/backend/VsRemote.Sample/LocalFolderFilesystem.cs
+++ b/backend/VsRemote.Sample/LocalFolderFilesystem.cs
@@ -72,6 +72,7 @@ public class LocalFolderFilesystem : VsRemoteFileSystem
                 new VsRemoteINode(
                     Path.GetFileName(path),
                     Directory.Exists(path) ? VsRemoteFileType.Directory : VsRemoteFileType.File,
+                    Readonly: (File.GetAttributes(path) | FileAttributes.ReadOnly) != 0,
                     ((DateTimeOffset)File.GetCreationTimeUtc(path)).ToUnixTimeSeconds(),
                     ((DateTimeOffset)File.GetLastWriteTimeUtc(path)).ToUnixTimeSeconds(),
                     ((DateTimeOffset)File.GetLastAccessTimeUtc(path)).ToUnixTimeSeconds()

--- a/backend/VsRemote.Sample/Program.cs
+++ b/backend/VsRemote.Sample/Program.cs
@@ -17,16 +17,16 @@ builder.WebHost.ConfigureKestrel(options =>
 //IVsRemoteFileSystemProvider fsProvider = new RootFsProvider(new InMemoryIndexedDictionaryFilesystem());
 
 // sample local-folder filesystem
-IVsRemoteFileSystemProvider fsProvider = new RootFsProvider(new LocalFolderFilesystem(@"C:\temp\bug\"));
+//IVsRemoteFileSystemProvider fsProvider = new RootFsProvider(new LocalFolderFilesystem(@"C:\temp\bug\"));
 
 // sample base-path filesystem that maps the "idx" and "temp" folders to two different filesystem implementations
-/*
-IVsRemoteFileSystemProvider fsProvider = new BasePathFsProvider(new()
+
+IVsRemoteFileSystemProvider fsProvider = new BasePathFsProvider(new Dictionary<string, IVsRemoteFileSystem>()
         {
             { "idx", new InMemoryIndexedDictionaryFilesystem() },
-            { "temp", new LocalFolderFilesystem(@"C:\temp\") }
+            { "temp", new LocalFolderFilesystem(@"C:\temp\bug\") }
         });
-*/
+
 
 /*
 // simple, commandless VsRemote configuration

--- a/backend/VsRemote.Sample/Program.cs
+++ b/backend/VsRemote.Sample/Program.cs
@@ -14,10 +14,10 @@ builder.WebHost.ConfigureKestrel(options =>
 });
 
 // sample in-memory filesystem
-IVsRemoteFileSystemProvider fsProvider = new RootFsProvider(new InMemoryIndexedDictionaryFilesystem());
+//IVsRemoteFileSystemProvider fsProvider = new RootFsProvider(new InMemoryIndexedDictionaryFilesystem());
 
 // sample local-folder filesystem
-//IVsRemoteFileSystemProvider fsProvider = new RootFsProvider(new LocalFolderFilesystem(@"C:\temp\"));
+IVsRemoteFileSystemProvider fsProvider = new RootFsProvider(new LocalFolderFilesystem(@"C:\temp\bug\"));
 
 // sample base-path filesystem that maps the "idx" and "temp" folders to two different filesystem implementations
 /*
@@ -47,6 +47,13 @@ builder.Services.AddVsRemote(vs =>
         .AddCommand(CommandFactory.FromAction(() => Console.WriteLine("ExecuteCommand OK!"), "test command"))
         .AddCommand(new SampleCommand());
 });
+builder.Services.AddLogging(builder => builder.AddSimpleConsole(options =>
+{
+    options.IncludeScopes = false;
+    options.TimestampFormat = "HH:mm:ss ";
+    options.SingleLine = true;
+
+}));
 
 var app = builder.Build();
 

--- a/backend/VsRemote.Sample/VsRemote.Sample.csproj
+++ b/backend/VsRemote.Sample/VsRemote.Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/backend/VsRemote.Sample/appsettings.json
+++ b/backend/VsRemote.Sample/appsettings.json
@@ -1,14 +1,20 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Warning",
+      "Grpc": "Warning"
     }
   },
   "AllowedHosts": "*",
   "Kestrel": {
     "EndpointDefaults": {
       "Protocols": "Http2"
+    },
+    "Endpoints": {
+      "MyHttpEndpoint": {
+        "Url": "http://0.0.0.0:5229"
+      }
     }
   }
 }

--- a/backend/VsRemote/Base/ReadonlyDictionaryFilesystem.cs
+++ b/backend/VsRemote/Base/ReadonlyDictionaryFilesystem.cs
@@ -15,14 +15,14 @@ public abstract class ReadonlyDictionaryFilesystem: VsRemoteFileSystem
     protected virtual bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
         => Data.TryGetValue(key, out value);
     private IEnumerable<IVsRemoteINode> _dataINodes
-        => Data.Select(f => new VsRemoteINode(f.Key, VsRemoteFileType.File, Epoch, Epoch, f.Value.Length));
+        => Data.Select(f => new VsRemoteINode(f.Key, VsRemoteFileType.File, Epoch, Epoch, Epoch, f.Value.Length) as IVsRemoteINode);
     private readonly long epoch = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
     protected virtual long Epoch => epoch;
     private readonly IVsRemoteINode _rootINode;
 
     protected ReadonlyDictionaryFilesystem()
     {
-        _rootINode = new VsRemoteINode(VsPath.ROOT, VsRemoteFileType.Directory, Epoch, Epoch);
+        _rootINode = new VsRemoteINode(VsPath.ROOT, VsRemoteFileType.Directory, Epoch, Epoch, Epoch);
 
     }
 
@@ -84,7 +84,7 @@ public abstract class ReadonlyDictionaryFilesystem: VsRemoteFileSystem
         throw new PermissionDenied();
     }
 
-    public override Task<long> WriteFile(string file2write, IVsRemoteINode parentDir, string[] parentPath, ReadOnlyMemory<byte> content)
+    public override Task<int> WriteFile(string file2write, IVsRemoteINode parentDir, string[] parentPath, ReadOnlyMemory<byte> content)
     {
         throw new PermissionDenied();
     }

--- a/backend/VsRemote/Base/ReadonlyDictionaryFilesystem.cs
+++ b/backend/VsRemote/Base/ReadonlyDictionaryFilesystem.cs
@@ -15,14 +15,14 @@ public abstract class ReadonlyDictionaryFilesystem: VsRemoteFileSystem
     protected virtual bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
         => Data.TryGetValue(key, out value);
     private IEnumerable<IVsRemoteINode> _dataINodes
-        => Data.Select(f => new VsRemoteINode(f.Key, VsRemoteFileType.File, Epoch, Epoch, Epoch, f.Value.Length) as IVsRemoteINode);
+        => Data.Select(f => new VsRemoteINode(f.Key, VsRemoteFileType.File, Readonly: true, Epoch, Epoch, Epoch, f.Value.Length) as IVsRemoteINode);
     private readonly long epoch = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
     protected virtual long Epoch => epoch;
     private readonly IVsRemoteINode _rootINode;
 
     protected ReadonlyDictionaryFilesystem()
     {
-        _rootINode = new VsRemoteINode(VsPath.ROOT, VsRemoteFileType.Directory, Epoch, Epoch, Epoch);
+        _rootINode = new VsRemoteINode(VsPath.ROOT, VsRemoteFileType.Directory, Readonly: true, Epoch, Epoch, Epoch);
 
     }
 
@@ -63,6 +63,7 @@ public abstract class ReadonlyDictionaryFilesystem: VsRemoteFileSystem
                             new VsRemoteINode(
                                 path[0],
                                 VsRemoteFileType.File,
+                                Readonly: true,
                                 Epoch, Epoch,
                                 data.Length
                             )

--- a/backend/VsRemote/Base/VsRemoteFileSystem.cs
+++ b/backend/VsRemote/Base/VsRemoteFileSystem.cs
@@ -176,7 +176,7 @@ public abstract class VsRemoteFileSystem : IVsRemoteFileSystem
         if (toPath_a.Length == 0)
             throw new InvalidPath();
         var fromInode = await Stat(fromPath_a);
-        var fromContainer = await GetParentDirectory(toPath_a);
+        var fromContainer = await GetParentDirectory(fromPath_a);
         var toContainer = await GetParentDirectory(toPath_a);
         bool exists;
         try

--- a/backend/VsRemote/Base/VsRemoteFileSystem.cs
+++ b/backend/VsRemote/Base/VsRemoteFileSystem.cs
@@ -16,6 +16,11 @@ public abstract class VsRemoteFileSystem : IVsRemoteFileSystem
     public abstract Task<IEnumerable<IVsRemoteINode>> ListDirectory(IVsRemoteINode dir, string[] path);
 
     public abstract Task<ReadOnlyMemory<byte>> ReadFile(IVsRemoteINode fileToRead, IVsRemoteINode parentDir, string[] parentPath);
+    public virtual async Task<ReadOnlyMemory<byte>> ReadFileOffset(IVsRemoteINode fileToRead, IVsRemoteINode parentDir, string[] parentPath, int offset, int length)
+    {
+        ReadOnlyMemory<byte> entireFile = await ReadFile(fileToRead, parentDir, parentPath);
+        return entireFile.Slice(offset, length);
+    }
 
     public abstract Task RemoveDirectory(IVsRemoteINode dir, string[] path, bool recursive);
 
@@ -23,7 +28,28 @@ public abstract class VsRemoteFileSystem : IVsRemoteFileSystem
 
     public abstract Task<IVsRemoteINode> Stat(string[] path);
 
-    public abstract Task<long> WriteFile(string file2write, IVsRemoteINode parentDir, string[] parentPath, ReadOnlyMemory<byte> content);
+    public abstract Task<int> WriteFile(string file2write, IVsRemoteINode parentDir, string[] parentPath, ReadOnlyMemory<byte> content);
+    public virtual async Task<int> WriteFileOffset(IVsRemoteINode inode2write, IVsRemoteINode parentDir, string[] parentPath, int offset, ReadOnlyMemory<byte> content)
+    {
+        ReadOnlyMemory<byte> entireFile = await ReadFile(inode2write, parentDir, parentPath);
+        if (offset > content.Length)
+            offset = content.Length; // ... what else?!
+        int newlen = entireFile.Length - offset + content.Length;
+        byte[] newfile = new byte[newlen];
+        entireFile[..offset].CopyTo(newfile);
+        content.Span.CopyTo(newfile.AsSpan()[offset..]);
+        return await WriteFile(inode2write.Name, parentDir, parentPath, newfile);
+    }
+
+    public virtual async Task<int> WriteFileAppend(IVsRemoteINode inode2write, IVsRemoteINode parentDir, string[] parentPath, ReadOnlyMemory<byte> content)
+    {
+        ReadOnlyMemory<byte> entireFile = await ReadFile(inode2write, parentDir, parentPath);
+        int newlen = entireFile.Length + content.Length;
+        byte[] newfile = new byte[newlen];
+        entireFile.CopyTo(newfile);
+        content.Span.CopyTo(newfile.AsSpan().Slice(entireFile.Length));
+        return await WriteFile(inode2write.Name, parentDir, parentPath, newfile);
+    }
 
 
     private async Task<(IVsRemoteINode INode, string[] Path)> GetParent(string[] path_a)
@@ -103,6 +129,23 @@ public abstract class VsRemoteFileSystem : IVsRemoteFileSystem
         }
     }
 
+    async Task<ReadOnlyMemory<byte>> IVsRemoteFileSystem.ReadFileOffset(string path, int offset, int length)
+    {
+        var path_a = Split(path);
+        if (path_a.Length == 0)
+        {
+            throw new IsADirectory(); // root IS a directory
+        }
+        else
+        {
+            var file = await Stat(path_a);
+            file.AssertNotDirectory();
+            var containingDir = await GetParentDirectory(path_a);
+            return await ReadFileOffset(file, containingDir.INode, containingDir.Path, offset, length);
+        }
+    }
+
+
     async Task IVsRemoteFileSystem.RemoveDirectory(string path, bool recursive)
     {
         var path_a = Split(path);
@@ -161,7 +204,7 @@ public abstract class VsRemoteFileSystem : IVsRemoteFileSystem
         return await Stat(path_a);
     }
 
-    async Task<long> IVsRemoteFileSystem.WriteFile(string path, ReadOnlyMemory<byte> content, bool overwriteIfExists, bool createIfNotExists)
+    async Task<int> IVsRemoteFileSystem.WriteFile(string path, ReadOnlyMemory<byte> content, bool overwriteIfExists, bool createIfNotExists)
     {
         var path_a = Split(path);
         if (path_a.Length == 0)
@@ -183,8 +226,30 @@ public abstract class VsRemoteFileSystem : IVsRemoteFileSystem
         }
         else
         {
-            throw new PermissionDenied();
+            throw new NotFound();
         }
+    }
+
+    async Task<int> IVsRemoteFileSystem.WriteFileOffset(string path, int offset, ReadOnlyMemory<byte> content)
+    {
+        var path_a = Split(path);
+        if (path_a.Length == 0)
+            throw new InvalidPath();
+
+        var parent = await GetParentDirectory(path_a);
+        IVsRemoteINode inode2write = await ((IVsRemoteFileSystem)this).Stat(path);
+        return await WriteFileOffset(inode2write, parent.INode, parent.Path, offset, content);
+    }
+
+    async Task<int> IVsRemoteFileSystem.WriteFileAppend(string path, ReadOnlyMemory<byte> content)
+    {
+        var path_a = Split(path);
+        if (path_a.Length == 0)
+            throw new InvalidPath();
+
+        var parent = await GetParentDirectory(path_a);
+        IVsRemoteINode inode2write = await ((IVsRemoteFileSystem)this).Stat(path);
+        return await WriteFileAppend(inode2write, parent.INode, parent.Path, content);
     }
     #endregion
 }

--- a/backend/VsRemote/Base/VsRemoteIndexedFileSystem.cs
+++ b/backend/VsRemote/Base/VsRemoteIndexedFileSystem.cs
@@ -26,8 +26,8 @@ public abstract class VsRemoteFileSystem<T> : IVsRemoteFileSystem where T: IEqua
     public abstract Task RenameFile(IVsRemoteINode<T> fromFile, string toName, IVsRemoteINode<T> toPath);
     public abstract Task OverwriteFile(IVsRemoteINode<T> fromFile, IVsRemoteINode<T> toFile);
 
-    public abstract Task<long> CreateFile(string file2write, IVsRemoteINode<T> parentDir, ReadOnlyMemory<byte> content);
-    public abstract Task<long> RewriteFile(IVsRemoteINode<T> file2rewrite, ReadOnlyMemory<byte> content);
+    public abstract Task<int> CreateFile(string file2write, IVsRemoteINode<T> parentDir, ReadOnlyMemory<byte> content);
+    public abstract Task<int> RewriteFile(IVsRemoteINode<T> file2rewrite, ReadOnlyMemory<byte> content);
 
     public abstract Task<IVsRemoteINode<T>> FindByName(string file, IVsRemoteINode<T> parentDir);
 
@@ -172,7 +172,7 @@ public abstract class VsRemoteFileSystem<T> : IVsRemoteFileSystem where T: IEqua
         return await GetLastChild(path_a);
     }
 
-    async Task<long> IVsRemoteFileSystem.WriteFile(string path, ReadOnlyMemory<byte> content, bool overwriteIfExists, bool createIfNotExists)
+    async Task<int> IVsRemoteFileSystem.WriteFile(string path, ReadOnlyMemory<byte> content, bool overwriteIfExists, bool createIfNotExists)
     {
         var path_a = Split(path);
         if (path_a.Length == 0)
@@ -205,6 +205,21 @@ public abstract class VsRemoteFileSystem<T> : IVsRemoteFileSystem where T: IEqua
                 }
             }
         }
+    }
+
+    Task<ReadOnlyMemory<byte>> IVsRemoteFileSystem.ReadFileOffset(string path, int offset, int length)
+    {
+        throw new NotImplementedException();
+    }
+
+    Task<int> IVsRemoteFileSystem.WriteFileOffset(string path, int offset, ReadOnlyMemory<byte> content)
+    {
+        throw new NotImplementedException();
+    }
+
+    Task<int> IVsRemoteFileSystem.WriteFileAppend(string path, ReadOnlyMemory<byte> content)
+    {
+        throw new NotImplementedException();
     }
     #endregion
 }

--- a/backend/VsRemote/Base/VsRemoteIndexedFileSystem.cs
+++ b/backend/VsRemote/Base/VsRemoteIndexedFileSystem.cs
@@ -23,7 +23,7 @@ public abstract class VsRemoteFileSystem<T> : IVsRemoteFileSystem where T: IEqua
     public virtual async Task<ReadOnlyMemory<byte>> ReadFileOffset(IVsRemoteINode<T> fileToRead, int offset, int length)
     {
         ReadOnlyMemory<byte> entireFile = await ReadFile(fileToRead);
-        return entireFile.Slice(offset, length);
+        return entireFile.Slice(offset, Math.Min(length, entireFile.Length));
     }
 
     public abstract Task RemoveDirectory(IVsRemoteINode<T> dir, bool recursive);
@@ -38,7 +38,7 @@ public abstract class VsRemoteFileSystem<T> : IVsRemoteFileSystem where T: IEqua
         ReadOnlyMemory<byte> entireFile = await ReadFile(inode2write);
         if (offset > content.Length)
             offset = content.Length; // ... what else?!
-        int newlen = entireFile.Length - offset + content.Length;
+        int newlen = offset + content.Length;
         byte[] newfile = new byte[newlen];
         entireFile[..offset].CopyTo(newfile);
         content.Span.CopyTo(newfile.AsSpan()[offset..]);

--- a/backend/VsRemote/Exceptions/FileExists.cs
+++ b/backend/VsRemote/Exceptions/FileExists.cs
@@ -2,7 +2,8 @@
 
 public class FileExists: VsException
 {
-    public override string ErrorCode => "E_EXISTS";
+    public const string ERROR_CODE = "E_EXISTS";
+    public override string ErrorCode => ERROR_CODE;
 
     public FileExists() : base("File or directory already exists (and it shouldn't)") { }
 

--- a/backend/VsRemote/Exceptions/IOError.cs
+++ b/backend/VsRemote/Exceptions/IOError.cs
@@ -2,7 +2,8 @@
 
 public class IOError: VsException
 {
-    public override string ErrorCode => "E_IO_ERROR";
+    public const string ERROR_CODE = "E_IO_ERROR";
+    public override string ErrorCode => ERROR_CODE;
 
     public IOError() : base("I/O Error") { }
 

--- a/backend/VsRemote/Exceptions/InvalidPath.cs
+++ b/backend/VsRemote/Exceptions/InvalidPath.cs
@@ -2,7 +2,8 @@
 
 public class InvalidPath : VsException
 {
-    public override string ErrorCode => "E_INVALID_PATH";
+    public const string ERROR_CODE = "E_INVALID_PATH";
+    public override string ErrorCode => ERROR_CODE;
 
     public InvalidPath() : base("Invalid path") { }
     public InvalidPath(string message) : base(message) { }

--- a/backend/VsRemote/Exceptions/IsADirectory.cs
+++ b/backend/VsRemote/Exceptions/IsADirectory.cs
@@ -2,7 +2,8 @@
 
 public class IsADirectory: VsException
 {
-    public override string ErrorCode => "E_IS_DIR";
+    public const string ERROR_CODE = "E_IS_DIR";
+    public override string ErrorCode => ERROR_CODE;
 
     public IsADirectory() : base("Path is a directory (and it shouldn't)") { }
 

--- a/backend/VsRemote/Exceptions/NotADirectory.cs
+++ b/backend/VsRemote/Exceptions/NotADirectory.cs
@@ -2,7 +2,8 @@
 
 public class NotADirectory: VsException
 {
-    public override string ErrorCode => "E_NOT_DIR";
+    public const string ERROR_CODE = "E_NOT_DIR";
+    public override string ErrorCode => ERROR_CODE;
 
     public NotADirectory() : base("Path is not a directory (and it should)") { }
 

--- a/backend/VsRemote/Exceptions/NotEmpty.cs
+++ b/backend/VsRemote/Exceptions/NotEmpty.cs
@@ -2,7 +2,8 @@
 
 public class NotEmpty: VsException
 {
-    public override string ErrorCode => "E_NOT_EMPTY";
+    public const string ERROR_CODE = "E_NOT_EMPTY";
+    public override string ErrorCode => ERROR_CODE;
 
     public NotEmpty() : base("Directory not empty!") { }
 

--- a/backend/VsRemote/Exceptions/NotFound.cs
+++ b/backend/VsRemote/Exceptions/NotFound.cs
@@ -2,7 +2,8 @@
 
 public class NotFound: VsException
 {
-    public override string ErrorCode => "E_NOT_FOUND";
+    public const string ERROR_CODE = "E_NOT_FOUND";
+    public override string ErrorCode => ERROR_CODE;
 
     public NotFound() : base("Path not found") { }
 

--- a/backend/VsRemote/Exceptions/PermissionDenied.cs
+++ b/backend/VsRemote/Exceptions/PermissionDenied.cs
@@ -2,7 +2,8 @@
 
 public class PermissionDenied : VsException
 {
-    public override string ErrorCode => "E_PERM_DENIED";
+    public const string ERROR_CODE = "E_PERM_DENIED";
+    public override string ErrorCode => ERROR_CODE;
 
     public PermissionDenied() : base("Permission denied") { }
 

--- a/backend/VsRemote/Exceptions/ServerError.cs
+++ b/backend/VsRemote/Exceptions/ServerError.cs
@@ -4,7 +4,8 @@ namespace VsRemote.Exceptions;
 
 public class ServerError : VsException
 {
-    public override string ErrorCode => "E_ERROR";
+    public const string ERROR_CODE = "E_ERROR";
+    public override string ErrorCode => ERROR_CODE;
 
     public ServerError(Exception ex) : base($"Server Error: {ex.Message}", ex) { }
 

--- a/backend/VsRemote/Exceptions/VsException.cs
+++ b/backend/VsRemote/Exceptions/VsException.cs
@@ -1,4 +1,5 @@
 ﻿using Grpc.Core;
+using System.Runtime.CompilerServices;
 using VsRemote.Model.Auth;
 
 namespace VsRemote.Exceptions;
@@ -16,7 +17,10 @@ public abstract class VsException: Exception
         {
             { "error_code", ErrorCode },
             { "error_message", Message }
-        });
+        })
+        {
+            HResult = ErrorCode.GetHashCode()
+        };
     }
 
     public static RpcException RpcFrom(Exception ex)
@@ -46,4 +50,12 @@ public abstract class VsException: Exception
             { "error_message", message ?? "Authentication error" }
         });
     }
+
+}
+
+public static class RpcExceptionExt
+{
+    public static string VsErrorCode(this RpcException ex)
+        => ex.Trailers?.Get("error_code")?.Value ?? ServerError.ERROR_CODE;
+
 }

--- a/backend/VsRemote/Interfaces/IVsRemoteFileSystem.cs
+++ b/backend/VsRemote/Interfaces/IVsRemoteFileSystem.cs
@@ -17,6 +17,9 @@ public interface IVsRemoteFileSystem
     public Task RenameFile(string fromPath, string toPath, bool overwrite);
 
     public Task<ReadOnlyMemory<byte>> ReadFile(string path);
+    public Task<ReadOnlyMemory<byte>> ReadFileOffset(string path, int offset, int length);
 
-    public Task<long> WriteFile(string path, ReadOnlyMemory<byte> content, bool overwriteIfExists, bool createIfNotExists);
+    public Task<int> WriteFile(string path, ReadOnlyMemory<byte> content, bool overwriteIfExists, bool createIfNotExists);
+    public Task<int> WriteFileOffset(string path, int offset, ReadOnlyMemory<byte> content);
+    public Task<int> WriteFileAppend(string path, ReadOnlyMemory<byte> content);
 }

--- a/backend/VsRemote/Interfaces/IVsRemoteFileSystem.cs
+++ b/backend/VsRemote/Interfaces/IVsRemoteFileSystem.cs
@@ -19,7 +19,11 @@ public interface IVsRemoteFileSystem
     public Task<ReadOnlyMemory<byte>> ReadFile(string path);
     public Task<ReadOnlyMemory<byte>> ReadFileOffset(string path, int offset, int length);
 
+    public Task CreateFile(string path);
+
     public Task<int> WriteFile(string path, ReadOnlyMemory<byte> content, bool overwriteIfExists, bool createIfNotExists);
+
     public Task<int> WriteFileOffset(string path, int offset, ReadOnlyMemory<byte> content);
+
     public Task<int> WriteFileAppend(string path, ReadOnlyMemory<byte> content);
 }

--- a/backend/VsRemote/Interfaces/IVsRemoteINode.cs
+++ b/backend/VsRemote/Interfaces/IVsRemoteINode.cs
@@ -8,5 +8,6 @@ public interface IVsRemoteINode
     VsRemoteFileType FileType { get; }
     long CTime { get; }
     long MTime { get; }
+    long ATime { get; }
     long Size { get; }
 }

--- a/backend/VsRemote/Interfaces/IVsRemoteINode.cs
+++ b/backend/VsRemote/Interfaces/IVsRemoteINode.cs
@@ -10,4 +10,5 @@ public interface IVsRemoteINode
     long MTime { get; }
     long ATime { get; }
     long Size { get; }
+    bool Readonly { get; }
 }

--- a/backend/VsRemote/Interfaces/IVsRemoteINodeExt.cs
+++ b/backend/VsRemote/Interfaces/IVsRemoteINodeExt.cs
@@ -13,7 +13,8 @@ public static class IVsRemoteINodeExt
             Name = remoteInode.Name,
             Ctime = remoteInode.CTime,
             Mtime = remoteInode.MTime,
-            Atime = remoteInode.ATime
+            Atime = remoteInode.ATime,
+            Readonly = remoteInode.Readonly
         };
     }
 

--- a/backend/VsRemote/Interfaces/IVsRemoteINodeExt.cs
+++ b/backend/VsRemote/Interfaces/IVsRemoteINodeExt.cs
@@ -12,7 +12,8 @@ public static class IVsRemoteINodeExt
             FileType = remoteInode.FileType.ToProtoBuf(),
             Name = remoteInode.Name,
             Ctime = remoteInode.CTime,
-            Mtime = remoteInode.MTime
+            Mtime = remoteInode.MTime,
+            Atime = remoteInode.ATime
         };
     }
 

--- a/backend/VsRemote/Interfaces/IVsRemoteINodeExt.cs
+++ b/backend/VsRemote/Interfaces/IVsRemoteINodeExt.cs
@@ -11,6 +11,7 @@ public static class IVsRemoteINodeExt
         {
             FileType = remoteInode.FileType.ToProtoBuf(),
             Name = remoteInode.Name,
+            Size = remoteInode.Size,
             Ctime = remoteInode.CTime,
             Mtime = remoteInode.MTime,
             Atime = remoteInode.ATime,

--- a/backend/VsRemote/Model/VsRemoteINode.cs
+++ b/backend/VsRemote/Model/VsRemoteINode.cs
@@ -6,6 +6,7 @@ namespace VsRemote.Model;
 public record VsRemoteINode (
     string Name,
     VsRemoteFileType FileType,
+    bool Readonly,
     long CTime,
     long MTime,
     long ATime,

--- a/backend/VsRemote/Model/VsRemoteINode.cs
+++ b/backend/VsRemote/Model/VsRemoteINode.cs
@@ -8,5 +8,6 @@ public record VsRemoteINode (
     VsRemoteFileType FileType,
     long CTime,
     long MTime,
+    long ATime,
     long Size = 0
 ): IVsRemoteINode;

--- a/backend/VsRemote/Model/VsRemoteINodeIndexed.cs
+++ b/backend/VsRemote/Model/VsRemoteINodeIndexed.cs
@@ -9,8 +9,9 @@ public record VsRemoteINode<T> (
     T? Parent,
     string Name,
     VsRemoteFileType FileType,
+    bool Readonly,
     long CTime,
     long MTime,
     long ATime,
     long Size = 0
-) : VsRemoteINode(Name, FileType, CTime, MTime, ATime, Size), IVsRemoteINode<T>  where T : IEquatable<T>; 
+) : VsRemoteINode(Name, FileType, Readonly, CTime, MTime, ATime, Size), IVsRemoteINode<T>  where T : IEquatable<T>; 

--- a/backend/VsRemote/Model/VsRemoteINodeIndexed.cs
+++ b/backend/VsRemote/Model/VsRemoteINodeIndexed.cs
@@ -11,5 +11,6 @@ public record VsRemoteINode<T> (
     VsRemoteFileType FileType,
     long CTime,
     long MTime,
+    long ATime,
     long Size = 0
-) : VsRemoteINode(Name, FileType, CTime, MTime, Size), IVsRemoteINode<T>  where T : IEquatable<T>; 
+) : VsRemoteINode(Name, FileType, CTime, MTime, ATime, Size), IVsRemoteINode<T>  where T : IEquatable<T>; 

--- a/backend/VsRemote/Model/VsRemoteRootINode.cs
+++ b/backend/VsRemote/Model/VsRemoteRootINode.cs
@@ -7,4 +7,4 @@ namespace VsRemote.Model;
 public record VsRemoteRootINode(
     long CTime,
     long MTime
-) : VsRemoteINode(VsPath.ROOT, VsRemoteFileType.Directory, CTime, MTime, 0);
+) : VsRemoteINode(VsPath.ROOT, VsRemoteFileType.Directory, false, CTime, MTime, 0);

--- a/backend/VsRemote/Model/VsRemoteRootINode.cs
+++ b/backend/VsRemote/Model/VsRemoteRootINode.cs
@@ -7,4 +7,4 @@ namespace VsRemote.Model;
 public record VsRemoteRootINode(
     long CTime,
     long MTime
-) : VsRemoteINode(VsPath.ROOT, VsRemoteFileType.Directory, CTime, MTime, 0), IVsRemoteINode;
+) : VsRemoteINode(VsPath.ROOT, VsRemoteFileType.Directory, CTime, MTime, 0);

--- a/backend/VsRemote/Model/VsRemoteRootINodeIndexed.cs
+++ b/backend/VsRemote/Model/VsRemoteRootINodeIndexed.cs
@@ -10,4 +10,4 @@ public record VsRemoteRootINode<T> (
     long CTime,
     long MTime,
     T? Parent = default
-) : VsRemoteINode<T>(Key, Parent, VsPath.ROOT, VsRemoteFileType.Directory, CTime, MTime, 0L), IVsRemoteINode<T>  where T : IEquatable<T>; 
+) : VsRemoteINode<T>(Key, Parent, VsPath.ROOT, VsRemoteFileType.Directory, Readonly: false, CTime, MTime, 0L), IVsRemoteINode<T>  where T : IEquatable<T>; 

--- a/backend/VsRemote/Protos/fs.proto
+++ b/backend/VsRemote/Protos/fs.proto
@@ -13,7 +13,10 @@ service VsRemote {
   rpc DeleteFile (DeleteFileRequest) returns (DeleteFileResponse);
   rpc RenameFile (RenameFileRequest) returns (RenameFileResponse);
   rpc ReadFile (ReadFileRequest) returns (ReadFileResponse);
+  rpc ReadFileOffset (ReadFileOffsetRequest) returns (ReadFileResponse);
   rpc WriteFile (WriteFileRequest) returns (WriteFileResponse);
+  rpc WriteFileOffset (WriteFileOffsetRequest) returns (WriteFileResponse);
+  rpc WriteFileAppend (WriteFileAppendRequest) returns (WriteFileResponse);
   rpc ListCommands (ListCommandsRequest) returns (ListCommandsResponse);
   rpc ExecuteCommand (ExecuteCommandRequest) returns (ExecuteCommandResponse);
 }
@@ -204,8 +207,15 @@ message ReadFileRequest {
 }
 
 message ReadFileResponse {
-    int64 length = 1;
+    int32 length = 1;
     bytes content = 2;
+}
+
+message ReadFileOffsetRequest {
+    string auth_token = 1;
+    string path = 2;
+    int32 offset = 3;
+    int32 length = 4;
 }
 
 
@@ -220,6 +230,19 @@ message WriteFileRequest {
     bytes content = 10;
 }
 
+message WriteFileOffsetRequest {
+    string auth_token = 1;
+    string path = 2;
+    int32 offset = 3;
+    bytes content = 10;
+}
+message WriteFileAppendRequest {
+    string auth_token = 1;
+    string path = 2;
+    bytes content = 10;
+}
+
+
 message WriteFileResponse {
-    int64 bytes_written = 1;
+    int32 bytes_written = 1;
 }

--- a/backend/VsRemote/Protos/fs.proto
+++ b/backend/VsRemote/Protos/fs.proto
@@ -56,6 +56,7 @@ message VsFsEntry {
     int64 ctime = 4;
     int64 atime = 5;
     int64 size = 7;
+    bool readonly = 8;
 }
 
 

--- a/backend/VsRemote/Protos/fs.proto
+++ b/backend/VsRemote/Protos/fs.proto
@@ -14,6 +14,7 @@ service VsRemote {
   rpc RenameFile (RenameFileRequest) returns (RenameFileResponse);
   rpc ReadFile (ReadFileRequest) returns (ReadFileResponse);
   rpc ReadFileOffset (ReadFileOffsetRequest) returns (ReadFileResponse);
+  rpc CreateFile (CreateFileRequest) returns (WriteFileResponse);
   rpc WriteFile (WriteFileRequest) returns (WriteFileResponse);
   rpc WriteFileOffset (WriteFileOffsetRequest) returns (WriteFileResponse);
   rpc WriteFileAppend (WriteFileAppendRequest) returns (WriteFileResponse);
@@ -53,7 +54,8 @@ message VsFsEntry {
     FileType file_type = 2;
     int64 mtime = 3;
     int64 ctime = 4;
-    int64 size = 5;
+    int64 atime = 5;
+    int64 size = 7;
 }
 
 
@@ -221,6 +223,11 @@ message ReadFileOffsetRequest {
 
 
 // Write File
+
+message CreateFileRequest {
+    string auth_token = 1;
+    string path = 2;
+}
 
 message WriteFileRequest {
     string auth_token = 1;

--- a/backend/VsRemote/Providers/BasePathFsProvider.cs
+++ b/backend/VsRemote/Providers/BasePathFsProvider.cs
@@ -80,7 +80,7 @@ public class BasePathFsProvider : IVsRemoteFileSystemProvider
                 long atime =
                     remoteFilesystems.Values.Select(fs => fs.RootINode.ATime).Concat(
                     mountPoints.Values.Select(mp => mp.virtualRootFs.RootINode.ATime)).Max();
-                return new VsRemoteINode(VsPath.ROOT, VsRemoteFileType.Directory, ctime, mtime, atime);
+                return new VsRemoteINode(VsPath.ROOT, VsRemoteFileType.Directory, Readonly: true, ctime, mtime, atime);
             }
         }
 
@@ -97,12 +97,14 @@ public class BasePathFsProvider : IVsRemoteFileSystemProvider
                 remoteFilesystems.Select(fs => new VsRemoteINode(
                 Name: fs.Key,
                 FileType: VsRemoteFileType.Directory,
+                Readonly: false,
                 CTime: fs.Value.RootINode.CTime,
                 MTime: fs.Value.RootINode.MTime,
                 ATime: fs.Value.RootINode.ATime
             ) as IVsRemoteINode).Concat(mountPoints.Select(mp => new VsRemoteINode(
                 Name: mp.Key,
                 FileType: VsRemoteFileType.Directory,
+                Readonly: false,
                 CTime: mp.Value.virtualRootFs.RootINode.CTime,
                 MTime: mp.Value.virtualRootFs.RootINode.ATime,
                 ATime: mp.Value.virtualRootFs.RootINode.MTime

--- a/backend/VsRemote/Providers/BasePathFsProvider.cs
+++ b/backend/VsRemote/Providers/BasePathFsProvider.cs
@@ -77,7 +77,10 @@ public class BasePathFsProvider : IVsRemoteFileSystemProvider
                 long ctime =
                     remoteFilesystems.Values.Select(fs => fs.RootINode.CTime).Concat(
                     mountPoints.Values.Select(mp => mp.virtualRootFs.RootINode.CTime)).Max();
-                return new VsRemoteINode(VsPath.ROOT, VsRemoteFileType.Directory, ctime, mtime);
+                long atime =
+                    remoteFilesystems.Values.Select(fs => fs.RootINode.ATime).Concat(
+                    mountPoints.Values.Select(mp => mp.virtualRootFs.RootINode.ATime)).Max();
+                return new VsRemoteINode(VsPath.ROOT, VsRemoteFileType.Directory, ctime, mtime, atime);
             }
         }
 
@@ -95,12 +98,14 @@ public class BasePathFsProvider : IVsRemoteFileSystemProvider
                 Name: fs.Key,
                 FileType: VsRemoteFileType.Directory,
                 CTime: fs.Value.RootINode.CTime,
-                MTime: fs.Value.RootINode.MTime
+                MTime: fs.Value.RootINode.MTime,
+                ATime: fs.Value.RootINode.ATime
             ) as IVsRemoteINode).Concat(mountPoints.Select(mp => new VsRemoteINode(
                 Name: mp.Key,
                 FileType: VsRemoteFileType.Directory,
                 CTime: mp.Value.virtualRootFs.RootINode.CTime,
-                MTime: mp.Value.virtualRootFs.RootINode.MTime
+                MTime: mp.Value.virtualRootFs.RootINode.ATime,
+                ATime: mp.Value.virtualRootFs.RootINode.MTime
             ) as IVsRemoteINode).Concat(rootFiles.ListDirectory(dir, VsPath.ROOT_PATH).GetAwaiter().GetResult())));
         }
 
@@ -119,7 +124,6 @@ public class BasePathFsProvider : IVsRemoteFileSystemProvider
             }
         }
 
-
         #region PermissionDenied methods
         public override Task CreateDirectory(string directoryName, IVsRemoteINode parentDir, string[] parentPath)
         {
@@ -131,7 +135,7 @@ public class BasePathFsProvider : IVsRemoteFileSystemProvider
             throw new PermissionDenied();
         }
 
-        public override Task<long> WriteFile(string file2write, IVsRemoteINode parentDir, string[] parentPath, ReadOnlyMemory<byte> content)
+        public override Task<int> WriteFile(string file2write, IVsRemoteINode parentDir, string[] parentPath, ReadOnlyMemory<byte> content)
         {
             throw new PermissionDenied();
         }
@@ -147,96 +151,5 @@ public class BasePathFsProvider : IVsRemoteFileSystemProvider
         }
 #endregion
 
-    }
-
-
-    private sealed class xReadOnlyVirtualRoot : IVsRemoteFileSystem
-    {
-        private readonly Dictionary<string, IVsRemoteFileSystem> remoteFilesystems;
-        private readonly Dictionary<string, BasePathFsProvider> mountPoints;
-        private readonly ReadonlyDictionaryFilesystem rootFiles;
-
-        public IVsRemoteINode RootINode
-        {
-            get
-            {
-                long mtime =
-                    remoteFilesystems.Values.Select(fs => fs.RootINode.MTime).Concat(
-                    mountPoints.Values.Select(mp => mp.virtualRootFs.RootINode.MTime)).Max();
-                long ctime =
-                    remoteFilesystems.Values.Select(fs => fs.RootINode.CTime).Concat(
-                    mountPoints.Values.Select(mp => mp.virtualRootFs.RootINode.CTime)).Max();
-                return new VsRemoteINode(VsPath.ROOT, Enums.VsRemoteFileType.Directory, ctime, mtime);
-            }
-        }
-
-        public xReadOnlyVirtualRoot(Dictionary<string, IVsRemoteFileSystem> remoteFilesystems, Dictionary<string, BasePathFsProvider> subMounts, ReadonlyDictionaryFilesystem rootFiles)
-        {
-            this.remoteFilesystems = remoteFilesystems;
-            this.mountPoints = subMounts;
-            this.rootFiles = rootFiles;
-        }
-
-        public Task CreateDirectory(string path)
-        {
-            throw new PermissionDenied();
-        }
-
-        public Task DeleteFile(string path)
-        {
-            throw new PermissionDenied();
-        }
-
-        public async Task<IEnumerable<IVsRemoteINode>> ListDirectory(string path)
-        {
-            return remoteFilesystems.Select(fs => new VsRemoteINode(
-                Name: fs.Key,
-                FileType: VsRemoteFileType.Directory,
-                CTime: fs.Value.RootINode.CTime,
-                MTime: fs.Value.RootINode.MTime
-            ) as IVsRemoteINode).Concat(mountPoints.Select(mp => new VsRemoteINode(
-                Name: mp.Key,
-                FileType: VsRemoteFileType.Directory,
-                CTime: mp.Value.virtualRootFs.RootINode.CTime,
-                MTime: mp.Value.virtualRootFs.RootINode.MTime
-            ) as IVsRemoteINode).Concat(await rootFiles.ListDirectory(rootFiles.RootINode, VsPath.ROOT_PATH)));
-        }
-
-        public async Task<ReadOnlyMemory<byte>> ReadFile(string path)
-        {
-            return await rootFiles.ReadFile(new VsRemoteINode(
-                Name: path,
-                FileType: VsRemoteFileType.Directory,
-                CTime: rootFiles.RootINode.CTime,
-                MTime: rootFiles.RootINode.MTime
-                ), rootFiles.RootINode, VsPath.ROOT_PATH);
-        }
-
-        public Task RemoveDirectory(string path, bool recursive)
-        {
-            throw new PermissionDenied();
-        }
-
-        public Task RenameFile(string fromPath, string toPath, bool overwrite)
-        {
-            throw new PermissionDenied();
-        }
-
-        public async Task<IVsRemoteINode> Stat(string path)
-        {
-            if (VsPath.IsRoot(path))
-            {
-                return RootINode;
-            }
-            else
-            {
-                return await rootFiles.Stat(VsPath.Split(path));
-            }
-        }
-
-        public Task<long> WriteFile(string path, ReadOnlyMemory<byte> content, bool overwriteIfExists, bool createIfNotExists)
-        {
-            throw new PermissionDenied();
-        }
     }
 }

--- a/backend/VsRemote/Services/VsRemoteService.cs
+++ b/backend/VsRemote/Services/VsRemoteService.cs
@@ -20,7 +20,7 @@ internal sealed class VsRemoteService : VsRemote.VsRemoteBase
 
     public override async Task<ListCommandsResponse> ListCommands(ListCommandsRequest request, ServerCallContext context)
     {
-        logger.LogTrace("ListCommands()");
+        logger.LogDebug("ListCommands()");
         await ValidateToken(request.AuthToken);
         try
         {
@@ -64,7 +64,7 @@ internal sealed class VsRemoteService : VsRemote.VsRemoteBase
 
     public override async Task<ExecuteCommandResponse> ExecuteCommand(ExecuteCommandRequest request, ServerCallContext context)
     {
-        logger.LogTrace("ExecuteCommand({cmd})", request.Command);
+        logger.LogDebug("ExecuteCommand({cmd})", request.Command);
         await ValidateToken(request.AuthToken);
         try
         {
@@ -296,7 +296,7 @@ internal sealed class VsRemoteService : VsRemote.VsRemoteBase
 
     public override async Task<ReadFileResponse> ReadFileOffset(ReadFileOffsetRequest request, ServerCallContext context)
     {
-        logger.LogTrace("ReadFileOffset({path}, {offset}, {length})", request.Path, request.Offset, request.Length);
+        logger.LogDebug("ReadFileOffset({path}, {offset}, {length})", request.Path, request.Offset, request.Length);
         await ValidateToken(request.AuthToken);
         try
         {
@@ -339,7 +339,7 @@ internal sealed class VsRemoteService : VsRemote.VsRemoteBase
 
     public override async Task<WriteFileResponse> WriteFile(WriteFileRequest request, ServerCallContext context)
     {
-        logger.LogTrace("WriteFile({path}, Create:{create}, Overwrite:{overwrite}, Buffer Length:{length})", request.Path, request.Create, request.Overwrite, request.Content.Length);
+        logger.LogDebug("WriteFile({path}, Create:{create}, Overwrite:{overwrite}, Buffer Length:{length})", request.Path, request.Create, request.Overwrite, request.Content.Length);
         await ValidateToken(request.AuthToken);
         try
         {
@@ -360,7 +360,7 @@ internal sealed class VsRemoteService : VsRemote.VsRemoteBase
 
     public override async Task<WriteFileResponse> WriteFileOffset(WriteFileOffsetRequest request, ServerCallContext context)
     {
-        logger.LogTrace("WriteFileOffset({path}, Offset:{offset}, Buffer Length:{length})", request.Path, request.Offset, request.Content.Length);
+        logger.LogDebug("WriteFileOffset({path}, Offset:{offset}, Buffer Length:{length})", request.Path, request.Offset, request.Content.Length);
         await ValidateToken(request.AuthToken);
         try
         {

--- a/backend/VsRemote/Services/VsRemoteService.cs
+++ b/backend/VsRemote/Services/VsRemoteService.cs
@@ -316,6 +316,27 @@ internal sealed class VsRemoteService : VsRemote.VsRemoteBase
         }
     }
 
+    public override async Task<WriteFileResponse> CreateFile(CreateFileRequest request, ServerCallContext context)
+    {
+        logger.LogTrace("CreateFile({path})", request.Path);
+        await ValidateToken(request.AuthToken);
+        try
+        {
+            var (RelativePath, RemoteFs) = remoteFsProvider.FromPath(request.Path, request.AuthToken);
+            await RemoteFs.CreateFile(RelativePath);
+            logger.LogDebug("CreateFile({path}) OK", request.Path);
+            return new WriteFileResponse()
+            {
+                BytesWritten = 0
+            };
+        }
+        catch(Exception ex)
+        {
+            logger.LogError("WriteFile({path}) ERR: {err}", request.Path, ex.Message);
+            throw VsException.RpcFrom(ex);
+        }
+    }
+
     public override async Task<WriteFileResponse> WriteFile(WriteFileRequest request, ServerCallContext context)
     {
         logger.LogTrace("WriteFile({path}, Create:{create}, Overwrite:{overwrite}, Buffer Length:{length})", request.Path, request.Create, request.Overwrite, request.Content.Length);

--- a/backend/VsRemote/Services/VsRemoteService.cs
+++ b/backend/VsRemote/Services/VsRemoteService.cs
@@ -147,7 +147,7 @@ internal sealed class VsRemoteService : VsRemote.VsRemoteBase
         {
             var (RelativePath, RemoteFs) = remoteFsProvider.FromPath(request.Path, request.AuthToken);
             var remoteInode = await RemoteFs.Stat(RelativePath);
-            logger.LogDebug("Stat({path}) OK", request.Path);
+            logger.LogTrace("Stat({path}) OK", request.Path);
             return new StatResponse()
             {
                 FileInfo = remoteInode.ToGrpc()

--- a/backend/VsRemote/Services/VsRemoteService.cs
+++ b/backend/VsRemote/Services/VsRemoteService.cs
@@ -294,9 +294,31 @@ internal sealed class VsRemoteService : VsRemote.VsRemoteBase
         }
     }
 
+    public override async Task<ReadFileResponse> ReadFileOffset(ReadFileOffsetRequest request, ServerCallContext context)
+    {
+        logger.LogTrace("ReadFileOffset({path}, {offset}, {length})", request.Path, request.Offset, request.Length);
+        await ValidateToken(request.AuthToken);
+        try
+        {
+            var (RelativePath, RemoteFs) = remoteFsProvider.FromPath(request.Path, request.AuthToken);
+            var fileContent = await RemoteFs.ReadFileOffset(RelativePath, request.Offset, request.Length);
+            logger.LogDebug("ReadFileOffset({path}) OK, {length} bytes read", request.Path, fileContent.Length);
+            return new ReadFileResponse()
+            {
+                Content = ByteString.CopyFrom(fileContent.Span),
+                Length = fileContent.Length
+            };
+        }
+        catch(Exception ex)
+        {
+            logger.LogError("ReadFileOffset({path}) ERR: {err}", request.Path, ex.Message);
+            throw VsException.RpcFrom(ex);
+        }
+    }
+
     public override async Task<WriteFileResponse> WriteFile(WriteFileRequest request, ServerCallContext context)
     {
-        logger.LogTrace("WriteFile({path}, Create:{create}, Overwrite:{overwrite}, Length:{length})", request.Path, request.Create, request.Overwrite, request.Content.Length);
+        logger.LogTrace("WriteFile({path}, Create:{create}, Overwrite:{overwrite}, Buffer Length:{length})", request.Path, request.Create, request.Overwrite, request.Content.Length);
         await ValidateToken(request.AuthToken);
         try
         {
@@ -311,6 +333,48 @@ internal sealed class VsRemoteService : VsRemote.VsRemoteBase
         catch(Exception ex)
         {
             logger.LogError("WriteFile({path}) ERR: {err}", request.Path, ex.Message);
+            throw VsException.RpcFrom(ex);
+        }
+    }
+
+    public override async Task<WriteFileResponse> WriteFileOffset(WriteFileOffsetRequest request, ServerCallContext context)
+    {
+        logger.LogTrace("WriteFileOffset({path}, Offset:{offset}, Buffer Length:{length})", request.Path, request.Offset, request.Content.Length);
+        await ValidateToken(request.AuthToken);
+        try
+        {
+            var (RelativePath, RemoteFs) = remoteFsProvider.FromPath(request.Path, request.AuthToken);
+            var bytesWritten = await RemoteFs.WriteFileOffset(RelativePath, request.Offset, request.Content.Memory);
+            logger.LogDebug("WriteFileOffset({path}) OK, {length} bytes written", request.Path, bytesWritten);
+            return new WriteFileResponse()
+            {
+                BytesWritten = bytesWritten
+            };
+        }
+        catch(Exception ex)
+        {
+            logger.LogError("WriteFileOffset({path}) ERR: {err}", request.Path, ex.Message);
+            throw VsException.RpcFrom(ex);
+        }
+    }
+
+    public override async Task<WriteFileResponse> WriteFileAppend(WriteFileAppendRequest request, ServerCallContext context)
+    {
+        logger.LogTrace("WriteFileAppend({path}, Buffer Length:{length})", request.Path, request.Content.Length);
+        await ValidateToken(request.AuthToken);
+        try
+        {
+            var (RelativePath, RemoteFs) = remoteFsProvider.FromPath(request.Path, request.AuthToken);
+            var bytesWritten = await RemoteFs.WriteFileAppend(RelativePath, request.Content.Memory);
+            logger.LogDebug("WriteFileAppend({path}) OK, {length} bytes written", request.Path, bytesWritten);
+            return new WriteFileResponse()
+            {
+                BytesWritten = bytesWritten
+            };
+        }
+        catch(Exception ex)
+        {
+            logger.LogError("WriteFileAppend({path}) ERR: {err}", request.Path, ex.Message);
             throw VsException.RpcFrom(ex);
         }
     }

--- a/backend/VsRemote/Utils/VsPath.cs
+++ b/backend/VsRemote/Utils/VsPath.cs
@@ -55,6 +55,10 @@ public class VsPath
         {
             throw new InvalidPath();
         }
+        if (path.Length == 1)
+        {
+            return ROOT;
+        }
         return Join(path.SkipA());
     }
 

--- a/backend/VsRemote/VsRemote.csproj
+++ b/backend/VsRemote/VsRemote.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/backend/VsRemote/VsRemote.csproj
+++ b/backend/VsRemote/VsRemote.csproj
@@ -14,9 +14,9 @@
     <RepositoryType>git</RepositoryType>
     <PackageOutputPath>bin\nuget</PackageOutputPath>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>© 2023 Mattia Merzi</Copyright>
+    <Copyright>© 2025 Mattia Merzi</Copyright>
     <ApplicationIcon>vsremote_icon.ico</ApplicationIcon>
-    <Version>0.0.1-alpha</Version>
+    <Version>0.0.3-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/VsRemote/VsRemote.csproj
+++ b/backend/VsRemote/VsRemote.csproj
@@ -31,17 +31,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.21.12" />
-    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.51.0" />
-    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.51.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.51.0">
+    <PackageReference Include="Google.Protobuf" Version="3.28.3" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.66.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.66.0" />
+    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.66.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.67.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <Protobuf Include="Protos\fs.proto" GrpcServices="Server" />
+    <Protobuf Include="Protos\fs.proto" GrpcServices="Both" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
A few more operations have been added that were necessary to create a mountable windows virtual filesystem.
Primarily, read/write with offset and the "readonly" attribute on inodes. 